### PR TITLE
ui: move react-scripts to devDependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "axios": "^0.21.2",
     "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react-dom": "^16.14.0"
+  },
+  "devDependencies": {
     "react-scripts": "^5.0.1"
   },
   "proxy": "http://localhost:5000",


### PR DESCRIPTION
Via https://stackoverflow.com/a/72921325, this seems to avoid baking in the react-scripts development dependency into the production app, which side-steps the vulnerability being flagged, as long as `npm audit --production` is used for the check. ¯\_(ツ)_/¯